### PR TITLE
docs: fix guide inaccuracies and contradictions

### DIFF
--- a/.cursor/rules/logging.mdc
+++ b/.cursor/rules/logging.mdc
@@ -1,19 +1,19 @@
 # Logging Rules
 
-- Use `log` from `src/utils/logger` instead of `console.log/error/warn/info/debug`
-- **No object logging**: Always stringify important parts only. Use `JSON.stringify()` for objects/arrays
+- Use `logger` from `src/utils/logger` instead of `console.log/error/warn/info/debug`
+- **No manual stringify**: Logger handles object serialization internally via `formatMessage`
 - Use appropriate log levels:
-  - `log.info()` - general information
-  - `log.warn()` - warnings
-  - `log.error()` - errors (with error messages, not full objects)
+  - `logger.info()` - general information
+  - `logger.warn()` - warnings
+  - `logger.error()` - errors (with error messages, not full objects)
 
 Examples:
 ```typescript
 // ❌ BAD
 console.log("event", event);
-log.info("chains:", chains);
+logger.info("chains:", JSON.stringify(chains));  // redundant stringify
 
 // ✅ GOOD
-logger.info("chains:", JSON.stringify(chains));
+logger.info("[myFn] chains:", chains);
 logger.error("Failed:", error instanceof Error ? error.message : String(error));
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ bun run typecheck:changed  # typecheck vs master (RUN BEFORE FINISHING WORK)
 ### Commanders (src/commanders/)
 | Commander | Files | Purpose |
 |-----------|-------|---------|
-| Librarian | ~270 files | Tree management, healing, codex generation |
-| Textfresser | ~17 files | Vocabulary commands (Generate, Translate) |
+| Librarian | ~170 files | Tree management, healing, codex generation |
+| Textfresser | ~48 files | Vocabulary commands (Generate, Translate) |
 
 ### Stateless Helpers (src/stateless-helpers/)
 - `note-metadata/` - Format-agnostic metadata read/write
@@ -71,12 +71,12 @@ const link = wikilinkHelper.findByTarget(text, "MyNote");
 ```
 
 ### Documentation (src/documentaion/)
-- `librarian-architrecture.md` - Main architecture doc
-- `librarian-pieces.md` - Refactoring details
+- `librarian-architecture.md` - Main architecture doc
 - `e2e-architecture.md` - E2E test architecture
 - `vam-architecture.md` - VAM dispatch, event pipeline, self-event tracking
 - `textfresser-architecture.md` - Textfresser commands, generate pipeline
 - `commands-and-behaviors-architecture.md` - Command executor + behavior manager
+- `linguistics-and-prompt-smith-architecture.md` - Linguistics pipeline, prompt-smith
 
 **Keep these docs up to date**: when changing behavior documented in `src/documentaion/`, update the relevant doc in the same PR.
 
@@ -94,7 +94,7 @@ DOM Event → Detector (encode) → Handler.doesApply (SYNC gate) → Handler.ha
 - **Detectors** (`user-event-interceptor/events/`) capture raw events, encode into `Payload` via `Codec`
 - **Two-phase handler**: `doesApply()` is SYNC (for `preventDefault`), `handle()` is ASYNC
 - **Three outcomes**: `Handled` (consumed), `Passthrough` (native + clipboard), `Modified` (transform payload)
-- **Handler registration**: `createHandlers()` in `actions-manager/behaviors/` maps `PayloadKind` → handler
+- **Handler registration**: `createHandlers()` in `managers/obsidian/behavior-manager/` maps `PayloadKind` → handler
 - **Stateless handlers**: clipboard, select-all (pure transforms, no commander)
 - **Stateful handlers**: route to Librarian (checkbox, wikilink) or Textfresser (wikilink click tracking)
 
@@ -202,7 +202,8 @@ Reason: `prompt-smith` / AI API code relies on v3 semantics (e.g. `z.record(valu
 
 ### Logging
 - Use `logger` from `src/utils/logger`, NOT console.*
-- Stringify objects: `logger.info("data:", JSON.stringify(obj))`
+- **No manual stringify**: Logger handles object serialization internally
+- Log levels: `info()`, `warn()`, `error()`
 
 ## Plan Mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ bun run typecheck:changed  # typecheck vs master (RUN BEFORE FINISHING WORK)
 ### Commanders (src/commanders/)
 | Commander | Files | Purpose |
 |-----------|-------|---------|
-| Librarian | ~270 files | Tree management, healing, codex generation |
-| Textfresser | ~17 files | Vocabulary commands (Generate, Translate) |
+| Librarian | ~170 files | Tree management, healing, codex generation |
+| Textfresser | ~48 files | Vocabulary commands (Generate, Translate) |
 
 ### Stateless Helpers (src/stateless-helpers/)
 - `note-metadata/` - Format-agnostic metadata read/write
@@ -71,12 +71,12 @@ const link = wikilinkHelper.findByTarget(text, "MyNote");
 ```
 
 ### Documentation (src/documentaion/)
-- `librarian-architrecture.md` - Main architecture doc
-- `librarian-pieces.md` - Refactoring details
+- `librarian-architecture.md` - Main architecture doc
 - `e2e-architecture.md` - E2E test architecture
 - `vam-architecture.md` - VAM dispatch, event pipeline, self-event tracking
 - `textfresser-architecture.md` - Textfresser commands, generate pipeline
 - `commands-and-behaviors-architecture.md` - Command executor + behavior manager
+- `linguistics-and-prompt-smith-architecture.md` - Linguistics pipeline, prompt-smith
 
 **Keep these docs up to date**: when changing behavior documented in `src/documentaion/`, update the relevant doc in the same PR.
 
@@ -94,7 +94,7 @@ DOM Event → Detector (encode) → Handler.doesApply (SYNC gate) → Handler.ha
 - **Detectors** (`user-event-interceptor/events/`) capture raw events, encode into `Payload` via `Codec`
 - **Two-phase handler**: `doesApply()` is SYNC (for `preventDefault`), `handle()` is ASYNC
 - **Three outcomes**: `Handled` (consumed), `Passthrough` (native + clipboard), `Modified` (transform payload)
-- **Handler registration**: `createHandlers()` in `actions-manager/behaviors/` maps `PayloadKind` → handler
+- **Handler registration**: `createHandlers()` in `managers/obsidian/behavior-manager/` maps `PayloadKind` → handler
 - **Stateless handlers**: clipboard, select-all (pure transforms, no commander)
 - **Stateful handlers**: route to Librarian (checkbox, wikilink) or Textfresser (wikilink click tracking)
 
@@ -202,7 +202,8 @@ Reason: `prompt-smith` / AI API code relies on v3 semantics (e.g. `z.record(valu
 
 ### Logging
 - Use `logger` from `src/utils/logger`, NOT console.*
-- Stringify objects: `logger.info("data:", JSON.stringify(obj))`
+- **No manual stringify**: Logger handles object serialization internally
+- Log levels: `info()`, `warn()`, `error()`
 
 ## Plan Mode
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,7 +2,7 @@ import winston from "winston";
 
 /**
  * Logger utility with winston + console transports.
- * Rule: No object logging - stringify important parts only.
+ * Objects are auto-serialized via formatMessage — no manual stringify needed.
  */
 
 const formatMessage = (message: string, ...args: unknown[]): string => {


### PR DESCRIPTION
## Summary
- Resolve logging contradiction: three separate files (CLAUDE.md, AGENTS.md, .cursor/rules/logging.mdc) told users to manually stringify objects, while `logger.ts` auto-serializes via `formatMessage`. Aligned all docs + JSDoc to "no manual stringify"
- Fix stale references: typo in `librarian-architrecture.md` filename, remove non-existent `librarian-pieces.md`, add missing `linguistics-and-prompt-smith-architecture.md`
- Update Commander file counts to match actual codebase (~270→~170 Librarian, ~17→~48 Textfresser)
- Fix wrong `createHandlers()` path (`actions-manager/behaviors/` → `managers/obsidian/behavior-manager/`)
- Fix `.cursor/rules/logging.mdc`: wrong export name (`log` → `logger`), stale examples
- Keep AGENTS.md and CLAUDE.md fully in sync

## Test plan
- [x] All 1008 unit tests pass
- [x] Only doc/comment changes — no runtime behavior affected
- [x] Verified all referenced files exist on master
- [x] Confirmed AGENTS.md and CLAUDE.md are byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)