### PR TITLE
refactor: extract duplicate code into shared helpers

### DIFF
--- a/src/commanders/librarian/delimiter-change-service.ts
+++ b/src/commanders/librarian/delimiter-change-service.ts
@@ -6,6 +6,7 @@ import {
 	type VaultAction,
 	VaultActionKind,
 } from "../../managers/obsidian/vault-action-manager/types/vault-action";
+import { getMdFilesInLibrary } from "../../stateless-helpers/library-files";
 import type { SuffixDelimiterConfig } from "../../types";
 import {
 	buildCanonicalDelimiter,
@@ -96,9 +97,6 @@ export class DelimiterChangeService {
 		};
 	}
 
-	/**
-	 * Collect all .md files in the library folder.
-	 */
 	private collectMdFilesInLibrary(libraryRoot: string): TFile[] {
 		const rootFolder = this.app.vault.getAbstractFileByPath(libraryRoot);
 		if (!rootFolder) {
@@ -108,11 +106,7 @@ export class DelimiterChangeService {
 			return [];
 		}
 
-		return this.app.vault.getFiles().filter((f) => {
-			return (
-				f.path.startsWith(`${libraryRoot}/`) && f.path.endsWith(".md")
-			);
-		});
+		return getMdFilesInLibrary(this.app.vault, libraryRoot);
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import type { SplitPathToMdFile } from "./managers/obsidian/vault-action-manager
 import { OverlayManager } from "./managers/overlay-manager";
 import { SettingsTab } from "./settings";
 import { ApiService } from "./stateless-helpers/api-service";
+import { getMdFilesInLibrary } from "./stateless-helpers/library-files";
 import {
 	DEFAULT_SETTINGS,
 	type SuffixDelimiterConfig,
@@ -605,11 +606,7 @@ export default class TextEaterPlugin extends Plugin {
 		}
 
 		// Count files that will be affected
-		const mdFiles = this.app.vault.getFiles().filter((f) => {
-			return (
-				f.path.startsWith(`${libraryRoot}/`) && f.path.endsWith(".md")
-			);
-		});
+		const mdFiles = getMdFilesInLibrary(this.app.vault, libraryRoot);
 
 		const filesToRename = mdFiles.filter((f) =>
 			oldPattern.test(f.basename),

--- a/src/managers/obsidian/user-event-interceptor/events/clipboard/detector.ts
+++ b/src/managers/obsidian/user-event-interceptor/events/clipboard/detector.ts
@@ -12,10 +12,10 @@
 import { type App, MarkdownView } from "obsidian";
 import { blockIdHelper } from "../../../../../stateless-helpers/block-id";
 import type { VaultActionManager } from "../../../vault-action-manager";
-import type { SplitPathToMdFile } from "../../../vault-action-manager/types/split-path";
 import { HandlerOutcome } from "../../types/handler";
 import { PayloadKind } from "../../types/payload-base";
 import type { HandlerInvoker } from "../../user-event-interceptor";
+import { getCurrentFilePath } from "../get-current-file-path";
 import { ClipboardCodec } from "./codec";
 import type { ClipboardPayload } from "./payload";
 
@@ -66,7 +66,7 @@ export class ClipboardDetector {
 		}
 
 		// Get current file path (may be null if no file open)
-		const splitPath = this.getCurrentFilePath();
+		const splitPath = getCurrentFilePath(this.app);
 
 		// Encode to payload
 		const payload = ClipboardCodec.encode(evt, selection, splitPath);
@@ -123,23 +123,5 @@ export class ClipboardDetector {
 	private getActiveFileBasename(): string | null {
 		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
 		return view?.file?.basename ?? null;
-	}
-
-	private getCurrentFilePath(): SplitPathToMdFile | undefined {
-		// Synchronously get current file path if available
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view?.file) return undefined;
-
-		const path = view.file.path;
-		const parts = path.split("/");
-		const filename = parts.pop() ?? "";
-		const basename = filename.replace(/\.md$/, "");
-
-		return {
-			basename,
-			extension: "md",
-			kind: "MdFile",
-			pathParts: parts,
-		};
 	}
 }

--- a/src/managers/obsidian/user-event-interceptor/events/get-current-file-path.ts
+++ b/src/managers/obsidian/user-event-interceptor/events/get-current-file-path.ts
@@ -1,0 +1,19 @@
+import { type App, MarkdownView } from "obsidian";
+import type { SplitPathToMdFile } from "../../vault-action-manager/types/split-path";
+
+export function getCurrentFilePath(app: App): SplitPathToMdFile | undefined {
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	if (!view?.file) return undefined;
+
+	const path = view.file.path;
+	const parts = path.split("/");
+	const filename = parts.pop() ?? "";
+	const basename = filename.replace(/\.md$/, "");
+
+	return {
+		basename,
+		extension: "md",
+		kind: "MdFile",
+		pathParts: parts,
+	};
+}

--- a/src/managers/obsidian/user-event-interceptor/events/select-all/detector.ts
+++ b/src/managers/obsidian/user-event-interceptor/events/select-all/detector.ts
@@ -7,10 +7,10 @@
 import type { EditorView } from "@codemirror/view";
 import { type App, MarkdownView, Platform } from "obsidian";
 import { DomSelectors } from "../../../../../utils/dom-selectors";
-import type { SplitPathToMdFile } from "../../../vault-action-manager/types/split-path";
 import { HandlerOutcome } from "../../types/handler";
 import { PayloadKind } from "../../types/payload-base";
 import type { HandlerInvoker } from "../../user-event-interceptor";
+import { getCurrentFilePath } from "../get-current-file-path";
 import { SelectAllCodec } from "./codec";
 import type { SelectAllPayload } from "./payload";
 
@@ -77,7 +77,7 @@ export class SelectAllDetector {
 		if (!content) return;
 
 		// Get current file path
-		const splitPath = this.getCurrentFilePath();
+		const splitPath = getCurrentFilePath(this.app);
 
 		// Encode to payload
 		const payload = SelectAllCodec.encode({
@@ -106,22 +106,5 @@ export class SelectAllDetector {
 			// For "handled" or "passthrough", nothing more to do
 			// (passthrough after preventDefault means no selection change)
 		});
-	}
-
-	private getCurrentFilePath(): SplitPathToMdFile | undefined {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view?.file) return undefined;
-
-		const path = view.file.path;
-		const parts = path.split("/");
-		const filename = parts.pop() ?? "";
-		const basename = filename.replace(/\.md$/, "");
-
-		return {
-			basename,
-			extension: "md",
-			kind: "MdFile",
-			pathParts: parts,
-		};
 	}
 }

--- a/src/managers/obsidian/user-event-interceptor/events/selection-changed/detector.ts
+++ b/src/managers/obsidian/user-event-interceptor/events/selection-changed/detector.ts
@@ -11,9 +11,9 @@
 
 import { type App, MarkdownView } from "obsidian";
 import { DomSelectors } from "../../../../../utils/dom-selectors";
-import type { SplitPathToMdFile } from "../../../vault-action-manager/types/split-path";
 import { PayloadKind } from "../../types/payload-base";
 import type { HandlerInvoker } from "../../user-event-interceptor";
+import { getCurrentFilePath } from "../get-current-file-path";
 import { SelectionChangedCodec } from "./codec";
 import type { SelectionChangedPayload } from "./payload";
 
@@ -102,7 +102,7 @@ export class SelectionChangedDetector {
 		const hasSelection = selectedText.length > 0;
 
 		// Get current file path
-		const splitPath = this.getCurrentFilePath();
+		const splitPath = getCurrentFilePath(this.app);
 
 		// Encode to payload
 		const payload = SelectionChangedCodec.encode({
@@ -122,22 +122,5 @@ export class SelectionChangedDetector {
 
 		// Invoke handler
 		void invoke();
-	}
-
-	private getCurrentFilePath(): SplitPathToMdFile | undefined {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view?.file) return undefined;
-
-		const path = view.file.path;
-		const parts = path.split("/");
-		const filename = parts.pop() ?? "";
-		const basename = filename.replace(/\.md$/, "");
-
-		return {
-			basename,
-			extension: "md",
-			kind: "MdFile",
-			pathParts: parts,
-		};
 	}
 }

--- a/src/stateless-helpers/library-files.ts
+++ b/src/stateless-helpers/library-files.ts
@@ -1,0 +1,10 @@
+import type { TFile, Vault } from "obsidian";
+
+export function getMdFilesInLibrary(
+	vault: Vault,
+	libraryRoot: string,
+): TFile[] {
+	return vault.getFiles().filter((f) => {
+		return f.path.startsWith(`${libraryRoot}/`) && f.path.endsWith(".md");
+	});
+}


### PR DESCRIPTION
## Summary
- Extract `getCurrentFilePath()` from 3 event detectors (clipboard, select-all, selection-changed) into shared `get-current-file-path.ts` helper
- Extract locator serialize-and-validate boilerplate in `from.ts` into generic `serializeAndBuildLocator()` helper with `SegmentIdForKind` type map
- Extract library MD file filter into `getMdFilesInLibrary()` helper in `stateless-helpers/library-files.ts`, used by `main.ts` and `delimiter-change-service.ts`

Net reduction of ~60 lines of duplicated code across 8 files (2 new, 6 modified).

## Test plan
- [x] All 1008 unit tests pass
- [x] Production build succeeds
- [x] No new lint warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)