### PR TITLE
Add code ownership boundary documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,23 @@
+# Code Ownership Boundaries for filler-de
+# See docs/ARCHITECTURE.md for domain descriptions.
+#
+# Each source file is assigned to exactly one ownership domain.
+# Patterns are ordered so that no two rules match the same file.
+
+# --- plugin-core: lifecycle, configuration, shared types ---
+/src/main.ts            @domain/plugin-core
+/src/settings.ts        @domain/plugin-core
+/src/types.ts           @domain/plugin-core
+
+# --- commands: user-facing Obsidian commands ---
+/src/commands/          @domain/commands
+
+# --- ai-api: external LLM integration ---
+/src/api.ts             @domain/ai-api
+
+# --- prompt-engineering: prompt templates and builders ---
+/src/prompts/           @domain/prompt-engineering
+
+# --- filesystem: vault file read/write helpers ---
+/src/utils.ts           @domain/filesystem
+/src/file.ts            @domain/filesystem

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,90 @@
+# filler-de Architecture
+
+## Ownership Domains
+
+The plugin is divided into five logical ownership domains. Each domain
+groups files by responsibility so that changes within a domain can be
+reviewed by the team most familiar with that area.
+
+### 1. plugin-core
+
+Entry point, settings UI, and shared type definitions.
+
+| File | Purpose |
+|------|---------|
+| `src/main.ts` | Plugin lifecycle (`onload` / `onunload`), command registration |
+| `src/settings.ts` | Settings tab, defaults, persistence |
+| `src/types.ts` | Shared TypeScript interfaces and type aliases |
+
+### 2. commands
+
+User-facing Obsidian commands that orchestrate the other domains.
+
+| File | Purpose |
+|------|---------|
+| `src/commands/addBacklinksToCurrentFile.ts` | Add backlinks to current note |
+| `src/commands/endgame.ts` | Endgame command logic |
+| `src/commands/fillTemplate.ts` | Fill a note template via AI |
+| `src/commands/formatSelectionWithNumber.ts` | Format selected text with numbering |
+| `src/commands/functions.ts` | Shared command helpers |
+| `src/commands/getInfinitiveAndEmoji.ts` | Look up infinitive + emoji |
+| `src/commands/insertReplyFromC1Richter.ts` | Insert C1 Richter reply |
+| `src/commands/insertReplyFromKeymaker.ts` | Insert Keymaker reply |
+| `src/commands/normalizeSelection.ts` | Normalize selected text |
+| `src/commands/translateSelection.ts` | Translate selected text |
+
+### 3. ai-api
+
+HTTP client for the external LLM provider.
+
+| File | Purpose |
+|------|---------|
+| `src/api.ts` | API request construction, response parsing, error handling |
+
+### 4. prompt-engineering
+
+Prompt templates and builders sent to the LLM.
+
+| File | Purpose |
+|------|---------|
+| `src/prompts/index.ts` | Re-exports / prompt registry |
+| `src/prompts/baseDict.ts` | Base dictionary prompt |
+| `src/prompts/c1Richter.ts` | C1 Richter prompt |
+| `src/prompts/determine-infinitive-and-pick-emoji.ts` | Infinitive + emoji prompt |
+| `src/prompts/full-dict-enrtie.ts` | Full dictionary entry prompt |
+| `src/prompts/generate-forms.ts` | Word-form generation prompt |
+| `src/prompts/keymaker.ts` | Keymaker prompt |
+| `src/prompts/morphems.ts` | Morpheme analysis prompt |
+| `src/prompts/normalize.ts` | Normalization prompt |
+| `src/prompts/translate-de-to-eng.ts` | DE-to-EN translation prompt |
+| `src/prompts/valence.ts` | Verb valence prompt |
+| `src/prompts/wip_keymaker.ts` | Keymaker (work-in-progress) prompt |
+
+### 5. filesystem
+
+Vault file-system helpers for reading and writing notes.
+
+| File | Purpose |
+|------|---------|
+| `src/utils.ts` | Path resolution, directory sharding, file creation helpers |
+| `src/file.ts` | File read/write operations |
+
+## Dependency Flow
+
+```
+plugin-core
+    |
+    v
+ commands
+   / \
+  v   v
+ai-api  filesystem
+  |
+  v
+prompt-engineering
+```
+
+`plugin-core` registers commands. Each command may call into `ai-api`
+(which uses prompts from `prompt-engineering`) and `filesystem` to read
+or write vault files. Domains at the bottom of the graph should never
+import from domains above them.


### PR DESCRIPTION
## Summary
- Add `CODEOWNERS` file mapping source files to 5 logical ownership domains
- Add `docs/ARCHITECTURE.md` describing module structure, responsibilities, and dependency flow

## Ownership Domains
1. **plugin-core** — `main.ts`, `settings.ts`, `types.ts`
2. **commands** — `commands/` directory (10 command files)
3. **ai-api** — `api.ts`
4. **prompt-engineering** — `prompts/` directory (12 prompt files)
5. **filesystem** — `utils.ts`, `file.ts`

## Changes from previous iterations
- Removed phantom `src/prompt.ts` reference (file does not exist)
- Eliminated CODEOWNERS precedence conflict (`/src/prompts/` now has a single owner)
- Removed unrelated source code changes to `src/utils.ts` and `src/commands/addBacklinksToCurrentFile.ts`
- This PR now contains **only documentation files** — no functional code changes

## Files Modified
- `CODEOWNERS` (new)
- `docs/ARCHITECTURE.md` (new)

Nightshift-Task: ownership-boundary