### PR TITLE
Fix cache key, newline stripping, and dead code bugs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -34,7 +34,6 @@ export class ApiService {
 		userInput: string,
 		responseSchema?: boolean
 	): Promise<string> {
-		const startTime = performance.now();
 		try {
 			let response: string | null = null;
 			// Remove leading tab characters from the system prompt
@@ -66,7 +65,7 @@ export class ApiService {
 						responseMimeType: `application/json`,
 					};
 
-			const chatKey = systemPrompt;
+			const chatKey = `${systemPrompt}::${!!responseSchema}`;
 			if (!this.chatSessions[chatKey]) {
 				const model = this.genAI.getGenerativeModel({
 					model: this.model,
@@ -89,8 +88,6 @@ export class ApiService {
 			const logResponse = response === null ? '' : response;
 			return logResponse;
 		} catch (error: any) {
-			const endTime = performance.now();
-			const duration = endTime - startTime;
 			throw new Error(error.message);
 		}
 	}

--- a/src/commands/fillTemplate.ts
+++ b/src/commands/fillTemplate.ts
@@ -4,7 +4,7 @@ import { prompts } from '../prompts';
 import { longDash } from '../utils';
 
 function blockOrEmpty(block: string): string {
-	return block.replace('\n', '') === longDash ? '' : block;
+	return block.trim() === longDash ? '' : block;
 }
 
 function extractFirstBracketedWord(text: string) {


### PR DESCRIPTION
## Summary
- **Cache key bug (api.ts)**: The chat session cache key only used `systemPrompt`, ignoring `responseSchema`. This caused sessions created without `responseSchema` to be reused for calls with `responseSchema=true`, resulting in wrong `generationConfig`. Fixed by including `responseSchema` in the cache key.
- **Newline stripping bug (fillTemplate.ts)**: `blockOrEmpty` used `String.replace('\n', '')` which only removes the first newline. Multi-line API responses like `'\n\n—'` wouldn't match `longDash`, so non-empty blocks leaked through. Fixed by using `.trim()`.
- **Dead code (api.ts)**: Removed unused `startTime`, `endTime`, and `duration` variables from the error handler.

## Test plan
- [ ] Verify `fillTemplate` correctly filters empty blocks with leading/trailing whitespace
- [ ] Verify API calls with different `responseSchema` values use separate chat sessions
- [ ] Run `npm run build` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)